### PR TITLE
change backslash to slash

### DIFF
--- a/hiwin_xeg_16_support/urdf/xeg_16.xacro
+++ b/hiwin_xeg_16_support/urdf/xeg_16.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="hiwin_xeg_16_gripper" >
-  <xacro:include filename="$(find hiwin_xeg_16_support)\urdf\xeg_16_macro.xacro" />
+  <xacro:include filename="$(find hiwin_xeg_16_support)/urdf/xeg_16_macro.xacro" />
   <xacro:gripper prefix="" />
 </robot>

--- a/hiwin_xeg_32_support/urdf/xeg_32.xacro
+++ b/hiwin_xeg_32_support/urdf/xeg_32.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="hiwin_xeg_32_gripper" >
-  <xacro:include filename="$(find hiwin_xeg_32_support)\urdf\xeg_32_macro.xacro" />
+  <xacro:include filename="$(find hiwin_xeg_32_support)/urdf/xeg_32_macro.xacro" />
   <xacro:gripper prefix="" />
 </robot>

--- a/hiwin_xeg_64_support/urdf/xeg_64.xacro
+++ b/hiwin_xeg_64_support/urdf/xeg_64.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="hiwin_xeg_64_gripper" >
-  <xacro:include filename="$(find hiwin_xeg_64_support)\urdf\xeg_64_macro.xacro" />
+  <xacro:include filename="$(find hiwin_xeg_64_support)/urdf/xeg_64_macro.xacro" />
   <xacro:gripper prefix="" />
 </robot>


### PR DESCRIPTION
Using backslash as directory separator will get error in Unix.
Changing backslash to slash should still work in Windows.